### PR TITLE
Fixes lack of edges and sides spacing

### DIFF
--- a/templates/blocks/featured_products.liquid
+++ b/templates/blocks/featured_products.liquid
@@ -4,12 +4,12 @@
 -%}
 
 <div
-  class="SC-ContentBlock SC-FeaturedProducts{% if count >= 4 %} tns-cards{% endif %} sc-ps sc-pe"
+  class="SC-ContentBlock SC-FeaturedProducts{% if count >= 4 %} tns-cards{% endif %}"
   id="{% if content_block.identifier != blank %}SC-ContentBlock-{{ content_block.identifier }}{% endif %}"
   data-cb="{{ content_block.identifier }}">
 
   {%- if content_block.products.size > 0 %}
-    <div class="SC-CardCarousel">
+    <div class="SC-CardCarousel sc-ps sc-pe">
       <div class="SC-CardCarousel_header sc-section_header sc-three-quarters-medium-and-up sc-ms-auto sc-flex-col {% if alignment == 'center-text' %}sc-text-center{% endif %}">
         {%- unless content_block.title == blank %}
           <h2 class="SC-CardCarousel_heading sc-section_heading">

--- a/templates/blocks/featured_products.liquid
+++ b/templates/blocks/featured_products.liquid
@@ -1,8 +1,10 @@
-{% assign alignment = content_block.alignment %}
-{% assign count = content_block.products.size %}
+{%- liquid
+    assign alignment = content_block.alignment
+    assign count = content_block.products.size 
+-%}
 
 <div
-  class="SC-ContentBlock SC-FeaturedProducts{% if count >= 4 %} tns-cards{% endif %}"
+  class="SC-ContentBlock SC-FeaturedProducts{% if count >= 4 %} tns-cards{% endif %} sc-ps sc-pe"
   id="{% if content_block.identifier != blank %}SC-ContentBlock-{{ content_block.identifier }}{% endif %}"
   data-cb="{{ content_block.identifier }}">
 


### PR DESCRIPTION
# Motivation

The current featured products works well if it gets wrapped within a container template which adds paddings and margins to the sides and edges and thus providing the correct spacing when it's used among other content blocks. However, if it's not wrapped with a container template it will expand full-width of its parent container.

## Notes and changes

This is a very minimal change, the reason is being kept minimal is due to the possibility of the user wrapping the featured products template within another container and adding more spacing which will make the slider to shrink even more.

A good example is shown below.

### Screenshots

<img width="450" alt="ft_products_before" src="https://github.com/user-attachments/assets/a7b7f67c-ed99-4466-b9b6-6eb843f05870">

<img width="450" alt="ft_products_after" src="https://github.com/user-attachments/assets/b49a7af8-7109-41ac-96b8-afc1eae353f2">
